### PR TITLE
Improve spec error messages

### DIFF
--- a/spec/scripts/float_spec.rb
+++ b/spec/scripts/float_spec.rb
@@ -12,7 +12,7 @@ describe "float_find_hypotenuse.rb" do
     output = with_captured_stdout { require_relative('../../float_find_hypotenuse')} 
     output = "empty" if output.empty? 
     expect(output.match?(/5.3/i)).to be(true),
-      "Expected float_find_hypotenuse.rb output to be '5.3\n', but was #{output}."
+      "Expected float_find_hypotenuse.rb output to be:\n5.3\nbut was:\n#{output}"
     
   end
 end
@@ -32,7 +32,7 @@ describe "float_round.rb" do
     output = with_captured_stdout { require_relative('../../float_round')} 
     output = "empty" if output.empty? 
     expect(output.match?(/3.333\n/i)).to be(true),
-      "Expected float_round.rb output to be '3.333\n', but was #{output}."
+      "Expected float_round.rb output to be\n3.333\nbut was\n#{output}"
 
   end
 end


### PR DESCRIPTION
Since grades can format `\n` now, separate expected and actual on their own lines